### PR TITLE
Support Stripe webhooks

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,9 +9,10 @@ use Mix.Config
 
 config :sponsors,
   ecto_repos: [Sponsors.Repo],
-  subscription_plan: System.get_env("STRIPE_PLAN"),
   stripe_module: Sponsors.Stripe,
-  subscription_module: Sponsors.Subscriptions
+  stripe_secret: "stripe_webhook_secret",
+  subscription_module: Sponsors.Subscriptions,
+  subscription_plan: "stripe_plan"
 
 # Configures the endpoint
 config :sponsors, SponsorsWeb.Endpoint,
@@ -31,7 +32,7 @@ config :sponsors, Sponsors.Guardian,
   issuer: "system76",
   secret_key: System.get_env("JWT_SECRET_KEY", "averysecretsecret")
 
-config :stripity_stripe, api_key: System.get_env("STRIPE_SECRET_KEY")
+config :stripity_stripe, api_key: "stripe_secret_key"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/lib/sponsors/invoices.ex
+++ b/lib/sponsors/invoices.ex
@@ -1,0 +1,17 @@
+defmodule Sponsors.Invoices do
+  @moduledoc """
+  Provides a simple interface for interacting with the `invoices` table
+  """
+
+  alias Sponsors.Repo
+  alias Sponsors.Schemas.{Invoice, Subscription}
+
+  def create(stripe_invoice_id, stripe_subscription_id, paid) do
+    with %{id: subscription_id} <- Repo.get_by(Subscription, stripe_subscription_id: stripe_subscription_id) do
+      params = %{paid: paid, stripe_invoice_id: stripe_invoice_id, subscription_id: subscription_id}
+      changeset = Invoice.changeset(%Invoice{}, params)
+
+      Repo.insert(changeset)
+    end
+  end
+end

--- a/lib/sponsors_web/cache_body_reader.ex
+++ b/lib/sponsors_web/cache_body_reader.ex
@@ -1,0 +1,7 @@
+defmodule SponsorsWeb.CacheBodyReader do
+  def read_body(conn, opts) do
+    {:ok, body, conn} = Plug.Conn.read_body(conn, opts)
+    conn = Plug.Conn.put_private(conn, :raw_body, body)
+    {:ok, body, conn}
+  end
+end

--- a/lib/sponsors_web/controllers/webhooks/stripe_controller.ex
+++ b/lib/sponsors_web/controllers/webhooks/stripe_controller.ex
@@ -1,0 +1,28 @@
+defmodule SponsorsWeb.Webhooks.StripeController do
+  use SponsorsWeb, :controller
+
+  alias Sponsors.Invoices
+
+  @supported_event_types ["invoice.payment_succeeded", "invoice.payment_failed"]
+
+  def create(conn, _params) do
+    raw_body = conn.private[:raw_body]
+
+    with [signature] <- get_req_header(conn, "stripe-signature"),
+         {:ok, event} <- Stripe.Webhook.construct_event(raw_body, signature, stripe_signing_secret()),
+         true <- event.type in @supported_event_types,
+         {invoice_id, stripe_subscription_id, paid} <- invoice_details(event) do
+      Invoices.create(invoice_id, stripe_subscription_id, paid)
+    end
+
+    text(conn, "Thanks!")
+  end
+
+  defp invoice_details(%{data: %{object: %{id: invoice_id, lines: lines, paid: paid}}}) do
+    [%{subscription: stripe_subscription_id}] = lines.data
+
+    {invoice_id, stripe_subscription_id, paid}
+  end
+
+  defp stripe_signing_secret, do: Application.get_env(:sponsors, :stripe_signing_secret)
+end

--- a/lib/sponsors_web/endpoint.ex
+++ b/lib/sponsors_web/endpoint.ex
@@ -21,6 +21,7 @@ defmodule SponsorsWeb.Endpoint do
 
   plug Plug.Parsers,
     parsers: [:urlencoded, :multipart, :json],
+    body_reader: {SponsorsWeb.CacheBodyReader, :read_body, []},
     pass: ["*/*"],
     json_decoder: Phoenix.json_library()
 

--- a/lib/sponsors_web/router.ex
+++ b/lib/sponsors_web/router.ex
@@ -13,6 +13,10 @@ defmodule SponsorsWeb.Router do
     pipe_through :api
 
     get "/health_check", HealthCheckController, :health_check
+
+    scope "/webhooks", Webhooks do
+      post "/stripe", StripeController, :create
+    end
   end
 
   scope "/", SponsorsWeb do

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Sponsors.MixProject do
       {:phoenix_ecto, "~> 4.0"},
       {:plug_cowboy, "~> 2.0"},
       {:postgrex, ">= 0.0.0"},
-      {:stripity_stripe, "~> 2.0"},
+      {:stripity_stripe, "~> 2.8"},
       # Dev & Test dependencies
       {:bypass, "~> 1.0", only: :test},
       {:credo, "~> 1.4", only: [:dev, :test]},


### PR DESCRIPTION
Implement support for Stripe webhooks, handling two particular events (at this time): `invoice.payment_succeeded` and `invoice.payment_failed`. Invoice payments are persisted to the database associated with their subscription.