### PR TITLE
Change to `canceled_at` was missed here

### DIFF
--- a/lib/sponsors/subscriptions.ex
+++ b/lib/sponsors/subscriptions.ex
@@ -48,7 +48,7 @@ defmodule Sponsors.Subscriptions do
   """
   def cancel(id) do
     with %{stripe_subscription_id: stripe_subscription_id} = subscription <- Repo.get(Subscription, id),
-         changeset = Subscription.changeset(subscription, %{canceled: true}),
+         changeset = Subscription.changeset(subscription, %{canceled_at: DateTime.utc_now()}),
          {:ok, _deleted_subscription} <- Repo.update(changeset),
          {:ok, _canceled_subscription} <- stripe().cancel(stripe_subscription_id) do
       :ok

--- a/test/sponsors/subscriptions_test.exs
+++ b/test/sponsors/subscriptions_test.exs
@@ -40,7 +40,8 @@ defmodule Sponsors.SubscriptionsTest do
       end)
 
       assert :ok = Subscriptions.cancel(id)
-      assert %{canceled_at: _, stripe_subscription_id: ^stripe_subscription_id} = Repo.get(Subscription, id)
+      assert %{canceled_at: canceled_at, stripe_subscription_id: ^stripe_subscription_id} = Repo.get(Subscription, id)
+      refute is_nil(canceled_at)
     end
   end
 end


### PR DESCRIPTION
When we updated the schema so `cancelled` would track _when_ the cancellation occurred, we changed the schema's field to `cancelled_at` 