### PR TITLE
Update guardian to handle "user:1234" JWT tokens

### DIFF
--- a/lib/sponsors/guardian.ex
+++ b/lib/sponsors/guardian.ex
@@ -1,6 +1,10 @@
 defmodule Sponsors.Guardian do
   use Guardian, otp_app: :sponsors
 
+  def resource_from_claims(%{"sub" => "user:" <> user_id}) do
+    {:ok, user_id}
+  end
+
   def resource_from_claims(_claims), do: :not_implemented
   def subject_for_token(_resource, _claims), do: :not_implemented
 end

--- a/lib/sponsors_web/auth_pipeline.ex
+++ b/lib/sponsors_web/auth_pipeline.ex
@@ -6,4 +6,5 @@ defmodule SponsorsWeb.AuthPipeline do
 
   plug Guardian.Plug.VerifyHeader, claims: %{"iss" => "system76", "typ" => "access"}
   plug Guardian.Plug.EnsureAuthenticated
+  plug Guardian.Plug.LoadResource, allow_blank: true
 end

--- a/lib/sponsors_web/controllers/subscription_controller.ex
+++ b/lib/sponsors_web/controllers/subscription_controller.ex
@@ -7,7 +7,7 @@ defmodule SponsorsWeb.SubscriptionController do
   action_fallback SponsorsWeb.FallbackController
 
   def index(conn, _params) do
-    user_id = Guardian.Plug.current_resource(conn)
+    internal_customer_id = Guardian.Plug.current_resource(conn)
     subscriptions = subscriptions().all(internal_customer_id)
     render(conn, "index.json", subscriptions: subscriptions)
   end
@@ -17,7 +17,7 @@ defmodule SponsorsWeb.SubscriptionController do
   a JSON payload that includes our "stripe_customer_id".
   """
   def create(conn, %{"stripe_customer_id" => stripe_customer_id} = params) do
-    with user_id when not is_nil(user_id) = Guardian.Plug.current_resource(conn),
+    with internal_customer_id when not is_nil(internal_customer_id) <- Guardian.Plug.current_resource(conn),
          alt_source = Map.get(params, "stripe_source_id"),
          {:ok, subscription} <- subscriptions().create(stripe_customer_id, internal_customer_id, alt_source) do
       conn

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -16,12 +16,12 @@ defmodule SponsorsWeb.AuthHelpers do
 
   We use `Guardian.Token.Jwt.create_token/2` directly rather than `encode_and_sign/2`
   since we don't implement, nor want to implement soley for testing, the Guardian callbacks
-  used to encode resource's struct and load the subject from storage. 
+  used to encode resource's struct and load the subject from storage.
 
   Neither functions are performed by this service.
   """
   def login(conn, customer_id, claim_overrides \\ %{}) do
-    claims = Map.merge(%{"iss" => "system76", "sub" => customer_id, "typ" => "access"}, claim_overrides)
+    claims = Map.merge(%{"iss" => "system76", "sub" => "user:" <> customer_id, "typ" => "access"}, claim_overrides)
 
     {:ok, token} = Guardian.Token.Jwt.create_token(Sponsors.Guardian, claims)
 


### PR DESCRIPTION
In the recognizer JWT switch, we changed the "sub" to be in the format of "user:1234" to allow expanding the future to support apps and what have you. This fixes the JWT decoding to expect "user:1234". I also moved the decode logic to the `Sponsors.Guardian` module so it's closer to our other projects.

You can take a look at the recognizer guardian code to confirm:
https://github.com/system76/recognizer/blob/master/lib/recognizer/guardian.ex