### PR TITLE
fix sometimes not having a customer email in stripe

### DIFF
--- a/lib/sponsors/invoices.ex
+++ b/lib/sponsors/invoices.ex
@@ -11,14 +11,19 @@ defmodule Sponsors.Invoices do
          {:ok, invoice} <- record_invoice(stripe_invoice_id, subscription_id, paid),
          {:ok, _subscription} <- update_subscription_expiration(subscription, expires_at),
          {:ok, %{email: email, name: full_name}} <- stripe().customer(stripe_customer_id) do
-      name = first_name(full_name)
-
-      email
-      |> Email.thank_you(name)
-      |> Mailer.send()
-
-      {:ok, invoice}
+      send_thank_you_email(invoice, email, full_name)
     end
+  end
+
+  defp send_thank_you_email(invoice, nil, _), do: {:ok, invoice}
+  defp send_thank_you_email(invoice, email, full_name) do
+    name = first_name(full_name)
+
+    email
+    |> Email.thank_you(name)
+    |> Mailer.send()
+
+    {:ok, invoice}
   end
 
   defp get_subscription(stripe_subscription_id),

--- a/lib/sponsors/invoices.ex
+++ b/lib/sponsors/invoices.ex
@@ -16,6 +16,7 @@ defmodule Sponsors.Invoices do
   end
 
   defp send_thank_you_email(invoice, nil, _), do: {:ok, invoice}
+
   defp send_thank_you_email(invoice, email, full_name) do
     name = first_name(full_name)
 


### PR DESCRIPTION
I'm not sure how this happens, but sometimes we do not have an email on the stripe customer, resulting in a bamboo mailer error:

```
Elixir.Plug.Conn.WrapperError: ** (Bamboo.NilRecipientsError) All recipients were set to nil. Must specify at least one recipient. Full email - %Bamboo.Email{assigns: %{}, attachments: [], bcc: nil, cc: nil, from: "no-reply@system76.com", headers: %{"X-Mailgun-Variables" => "{\"name\":\"Pop!_OS Supporter\"}"}, html_body: nil, private: %{template: "pop_thankyou"}, subject: "Thank you for your support!", text_body: nil, to: nil}
```